### PR TITLE
fix(deploy): 의존성 설치에서 include 옵션 추가

### DIFF
--- a/.github/workflows/deploy-to-production.yaml
+++ b/.github/workflows/deploy-to-production.yaml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --omit=dev
+          npm ci --include=dev
         timeout-minutes: 15
 
       - name: Setup PM2

--- a/.github/workflows/deploy-to-staging.yaml
+++ b/.github/workflows/deploy-to-staging.yaml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --omit=dev
+          npm ci --include=dev
         timeout-minutes: 15
 
       - name: Setup PM2


### PR DESCRIPTION
1. `npm ci --include=dev`로 수정함